### PR TITLE
Update 04_game_spec.rb

### DIFF
--- a/spec/04_game_spec.rb
+++ b/spec/04_game_spec.rb
@@ -110,7 +110,7 @@ describe 'Game' do
       game = Game.new
       game.board.cells = ["X", "O", "X",
                           "O", "O", "X",
-                          "O", "O", "X"]
+                          " ", " ", "X"]
 
       expect(game.won?).to contain_exactly(2, 5, 8)
     end


### PR DESCRIPTION
Original board has two winners Os and Xs down the middle. Test specifically asks for the X winning combo of 2, 5, 8, but students would probably get the O winning combo of 1, 4, 7 back first depending on the order in their WIN_COMBINATIONS definition. I had to move [2,5,8] ahead of [1,4,7] to get it to pass.
x o x   =>    x o x
o o x   =>   o o x
o o x   =>     -  - x